### PR TITLE
✨ Kakao-ci workflows 기능 추가

### DIFF
--- a/.github/workflows/kakao_ci.yml
+++ b/.github/workflows/kakao_ci.yml
@@ -1,0 +1,89 @@
+name: BE CI
+run-name: Deploy by @${{ github.actor }} 
+
+on: 
+    push: 
+        branches: 
+            - main
+            - develop
+    pull_request:
+        types: [review_requested, opened, reopened, ready_for_review]
+    pull_request_review:
+        types: [submitted]
+
+jobs:
+    build-and-notify:
+        runs-on: self-hosted
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup Chrome
+              uses: browser-actions/setup-chrome@v1
+
+            - name: Determine event type and trigger action at Windows
+              if: runner.os == 'Windows'
+              run: |
+                if ( "${{github.event_name}}" -eq "push" ) {
+                  $TITLE="[${{github.actor}}]_${{ github.event_name }}"
+                  $DESC="${{ github.event.head_commit.message }}".split("`n")[0]
+                  echo "TITLE=$TITLE" >> $env:GITHUB_OUTPUT
+                  echo "DESC=$DESC" >> $env:GITHUB_OUTPUT
+                } elseif ( "${{github.event_name}}" -eq "pull_request" ) {
+                  $TITLE="[${{github.actor}}]_${{ github.event_name }}" 
+                  $DESC="${{ github.event.pull_request.title }}".split("`n")[0]
+                  echo "TITLE=$TITLE" >> $env:GITHUB_OUTPUT
+                  echo "DESC=$DESC" >> $env:GITHUB_OUTPUT
+                } elseif ( "${{github.event_name}}" -eq "pull_request_review" ) {
+                  $TITLE="${{github.actor}}]_${{ github.event_name }}"
+                  $DESC="${{ github.event.pull_request.title }}".split("`n")[0]
+                  echo "TITLE=$TITLE" >> $env:GITHUB_OUTPUT
+                  echo "DESC=$DESC" >> $env:GITHUB_OUTPUT
+                }
+                $CHROME_PATH = (Join-Path (Join-Path (Split-Path (Split-Path "${{github.workspace}}") -Parent) "_tool\chromium\latest\x64") "chrome.exe")
+                echo "CHROME_PATH=$CHROME_PATH" >> $env:GITHUB_OUTPUT
+              id: determine_event_type_windows
+
+            - name: Determine event type and trigger action at macOS
+              if: runner.os == 'macOS' 
+              run: |
+                if [ ${{github.event_name}} == 'push' ]; then
+                  echo "TITLE=[${{github.actor}}]_${{ github.event_name }}" >> $GITHUB_OUTPUT
+                  echo "DESC='$(echo '${{ github.event.head_commit.message }}' | awk '{printf "%s", $0}')'" >> $GITHUB_OUTPUT
+                elif [ ${{github.event_name}} == 'pull_request' ]; then
+                  echo "TITLE='[${{github.actor}}]_${{ github.event_name }}'" >> $GITHUB_OUTPUT
+                  echo "DESC='$(echo '${{ github.event.pull_request.title }}' | awk '{printf "%s", $0}')'" >> $GITHUB_OUTPUT
+                elif [ ${{github.event_name}} == 'pull_request_review' ]; then
+                  echo "TITLE='[${{github.actor}}]_${{ github.event_name }}'" >> $GITHUB_OUTPUT
+                  echo "DESC='$(echo '${{ github.event.pull_request.title }}' | awk '{printf "%s", $0}')'" >> $GITHUB_OUTPUT
+                fi
+                echo "CHROME_PATH='$(echo "$(dirname "$(dirname "${GITHUB_WORKSPACE}")")/_tool/chromium/latest/x64/Chromium.app/Contents/MacOS/Chromium")'" >> $GITHUB_OUTPUT
+              id: determine_event_type_mac
+
+            - name: run kakao-chat at Windows
+              if: runner.os == 'Windows'
+              uses: psychology50/kakao-chat-ci@main
+              env:
+                KAKAO_CLIENT: ${{ secrets.KAKAO_CLIENT }}
+                KAKAO_EMAIL: ${{ secrets.KAKAO_EMAIL }}
+                KAKAO_PASSWORD: ${{ secrets.KAKAO_PASSWORD }}
+                KAKAO_TEMPLATE_ID: 97232
+                KAKAO_SENDER_TEMPLATE_ID: 97280
+                KAKAO_REDIRECT_URL: http://localhost:3000/oauth/kakao/callback
+                TITLE: ${{ steps.determine_event_type_windows.outputs.TITLE }}
+                DESC: ${{ steps.determine_event_type_windows.outputs.DESC }}
+                CHROME_PATH: ${{ steps.determine_event_type_windows.outputs.CHROME_PATH }}
+
+            - name: run kakao-chat at macOS
+              if: runner.os == 'macOS'
+              uses: psychology50/kakao-chat-ci@main
+              env:
+                KAKAO_CLIENT: ${{ secrets.KAKAO_CLIENT }}
+                KAKAO_EMAIL: ${{ secrets.KAKAO_EMAIL }}
+                KAKAO_PASSWORD: ${{ secrets.KAKAO_PASSWORD }}
+                KAKAO_TEMPLATE_ID: 97232
+                KAKAO_SENDER_TEMPLATE_ID: 97280
+                KAKAO_REDIRECT_URL: http://localhost:3000/oauth/kakao/callback
+                TITLE: ${{ steps.determine_event_type_mac.outputs.TITLE }}
+                DESC: ${{ steps.determine_event_type_mac.outputs.DESC }}
+                CHROME_PATH: ${{ steps.determine_event_type_mac.outputs.CHROME_PATH }}


### PR DESCRIPTION
## 작업 이유
- 깃헙 이벤트를 카카오톡 알림으로 전송

## 작업 사항
- workflows 작성
- kakao-chat application 기능을 구현한 action 릴리즈

1. 이벤트 유형 및 작업 트리거 설정
    - 워크플로우는 주로 main 브랜치와 develop 브랜치에 대한 push 이벤트 및 pull_request 관련 이벤트에서 작동합니다. 이로써 코드 변경사항을 반영하거나 새로운 기능을 개발할 때 워크플로우가 실행됩니다.
2. 빌드 및 알림 작업
    - 이 단계에서는 코드를 빌드하고 사용자에게 알림을 보내는 작업을 수행합니다.
    - 코드를 체크아웃하여 현재 워크스페이스로 가져옵니다.
    - Chrome을 설정하여 웹 테스트에 사용할 수 있도록 준비합니다.
    - 운영체제(OS)에 따라 다른 작업을 수행합니다.
          + Windows OS: push, pull_request, pull_request_review 이벤트에 따라 제목(TITLE)과 설명(DESC)을 가져와서 준비합니다. 또한 Chromium의 경로(CHROME_PATH)를 계산하여 설정합니다.
          + macOS: 마찬가지로 이벤트 유형에 따라 제목과 설명을 가져오고 Chromium 경로를 설정합니다.
3. Kakao-Chat 액션 실행
    - 이 단계에서는 설정된 액션인 psychology50/kakao-chat-ci를 실행합니다. 이 액션은 Kakao 메시지를 보내는 데 사용됩니다.
    - 환경 변수를 설정하여 Kakao API에 필요한 정보를 제공하고, 이전 단계에서 추출한 제목(TITLE), 설명(DESC), Chromium 경로(CHROME_PATH) 등을 전달합니다.

## 이슈 연결
close #17 